### PR TITLE
Add --use_dft for more precise measurements

### DIFF
--- a/bode.py
+++ b/bode.py
@@ -88,6 +88,11 @@ if not args.MANUAL_SETTINGS:
     scope.set_channel_offset(1, 0)
     scope.set_channel_offset(2, 0)
 
+    # Display one period in 3 divs
+    period = (1/MIN_FREQ) / 3
+    scope.timebase_scale = period
+    scope.run()
+
     # Set the sensitivity according to the selected voltage
     scope.set_channel_scale(1, args.VOLTAGE / 3, use_closest_match=True)
     # Be a bit more pessimistic for the default voltage, because we run into problems if it is too confident

--- a/dft.py
+++ b/dft.py
@@ -1,0 +1,50 @@
+# This module implements DFT-based measurement of sine wave amplitude and phase.
+# By averaging over all the samples, it is more precise than just using
+# the scope's built-in Vpp and phase measurements.
+
+import time
+import numpy
+import math
+import cmath
+
+def measure_with_dft(scope, frequency):
+    scope.single()
+    waittime = 0
+    while scope.running:
+        time.sleep(0.01)
+        waittime += 1
+        if waittime % 10 == 0: scope.tforce()
+    
+    ch1 = scope.get_waveform_samples(1, 'NORM')
+    ch2 = scope.get_waveform_samples(2, 'NORM')
+    samplerate = 1.0 / scope.waveform_preamble_dict['xinc']
+    
+    # Trim the data to full number of periods
+    samples_per_period = samplerate / frequency
+    periods = int(len(ch1) / samples_per_period)
+    samples = round(periods * samples_per_period)
+    ch1 = ch1[:samples]
+    ch2 = ch2[:samples]
+    
+    if periods <= 0:
+        return 0, 0, 0
+    
+    # Perform DFT at a single frequency
+    exp = numpy.exp(math.tau * 1j * numpy.linspace(0, periods, samples, endpoint = False))
+    dft1 = numpy.sum(numpy.multiply(exp, ch1)) / samples
+    dft2 = numpy.sum(numpy.multiply(exp, ch2)) / samples
+    
+    amplitude1 = 4 * abs(dft1) # Convert to Vpp reading
+    amplitude2 = 4 * abs(dft2)
+    phase = cmath.phase(dft1) - cmath.phase(dft2)
+    deg_phase = (numpy.degrees(phase) + 180.0) % 360.0 - 180.0
+    
+    return amplitude1, amplitude2, deg_phase
+
+if __name__ == '__main__':
+    # Test this module with "python dft.py 192.168.100.10 10000"
+    import ds1054z
+    import sys
+    scope = ds1054z.DS1054Z(sys.argv[1])
+    freq = float(sys.argv[2])
+    print(measure_with_dft(scope, freq))


### PR DESCRIPTION
First of all, thanks for sharing the script!

I've added an option to download the screen data and perform Fourier transform on it. This way the amplitude and phase are averaged over all samples, giving more accurate results than an 8-bit ADC would normally allow. It's a bit slower than scope's built-in measurements, so I added it as a separate option.

Here are some examples of an RC filter, first with traditional Vpp measurement method:

![vpp_amplitude](https://user-images.githubusercontent.com/922265/102191582-478e0780-3ec2-11eb-94e2-1a1c9107fb52.png)
![vpp_phase](https://user-images.githubusercontent.com/922265/102191585-49f06180-3ec2-11eb-912b-04e9400a7dd3.png)

And then with DFT method:

![dft_amplitude](https://user-images.githubusercontent.com/922265/102191612-54126000-3ec2-11eb-9261-2dcfdd0d5c0d.png)
![dft_phase](https://user-images.githubusercontent.com/922265/102191624-583e7d80-3ec2-11eb-8512-900ae2dd3202.png)
